### PR TITLE
Add cd and ls commands

### DIFF
--- a/bash/src/main/java/ru/hse/homework/interfaces/execution/Task.java
+++ b/bash/src/main/java/ru/hse/homework/interfaces/execution/Task.java
@@ -1,5 +1,7 @@
 package ru.hse.homework.interfaces.execution;
 
+import ru.hse.homework.realisation.Environment;
+
 /**
  * Shell command
  */
@@ -14,6 +16,6 @@ public interface Task {
      * @return result of task
      * @throws Exception if smth wrong during task execution
      */
-    String execute() throws Exception;
+    String execute(Environment environment) throws Exception;
     String[] getArgs();
 }

--- a/bash/src/main/java/ru/hse/homework/realisation/Environment.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/Environment.java
@@ -11,7 +11,7 @@ public class Environment {
     }
 
     public Path getCurrentPath() {
-        return currentPath;
+        return currentPath.normalize();
     }
 
     public void setCurrentPath(Path currentPath) {

--- a/bash/src/main/java/ru/hse/homework/realisation/Environment.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/Environment.java
@@ -1,0 +1,20 @@
+package ru.hse.homework.realisation;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Environment {
+    private Path currentPath = null;
+
+    public Environment() {
+        this.currentPath = Paths.get(".").toAbsolutePath();
+    }
+
+    public Path getCurrentPath() {
+        return currentPath;
+    }
+
+    public void setCurrentPath(Path currentPath) {
+        this.currentPath = currentPath;
+    }
+}

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/Executor.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/Executor.java
@@ -5,6 +5,7 @@ import ru.hse.homework.interfaces.Writer;
 import ru.hse.homework.interfaces.analizers.Lexer;
 import ru.hse.homework.interfaces.analizers.Parser;
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 import ru.hse.homework.realisation.StreamReader;
 import ru.hse.homework.realisation.StreamWriter;
 import ru.hse.homework.realisation.analizers.SpaceLexer;
@@ -18,6 +19,7 @@ public class Executor implements ru.hse.homework.interfaces.execution.Executor {
         Lexer lexer = new SpaceLexer();
         Parser parser = new WordsParser();
         Writer writer = new StreamWriter(System.out);
+        Environment environment = new Environment();
         while (true) {
             String command = reader.getNextCommand();
             String[] taskResult = new String[1];
@@ -28,7 +30,7 @@ public class Executor implements ru.hse.homework.interfaces.execution.Executor {
                     if (taskResult[0] != null) {
                         task.setArgs(taskResult);
                     }
-                    taskResult[0] = task.execute();
+                    taskResult[0] = task.execute(environment);
                 }
                 writer.writeCommandResult(taskResult[0].getBytes());
             } catch (Exception e) {

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Cat.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Cat.java
@@ -1,6 +1,7 @@
 package ru.hse.homework.realisation.execution.tasks;
 
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -16,7 +17,7 @@ public class Cat implements Task {
         arg = args[0];
     }
 
-    public String execute() throws IOException {
+    public String execute(Environment environment) throws IOException {
         char[] buf = new char[256];
         StringBuilder result = new StringBuilder();
         try (FileReader reader = new FileReader(arg)) {

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Cd.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Cd.java
@@ -9,7 +9,7 @@ import java.nio.file.Paths;
 
 public class Cd implements Task {
     public static final String COMMAND = "cd";
-    private String[] args;
+    private String[] args = new String[0];
 
     @Override
     public void setArgs(String[] args) throws Exception {
@@ -19,16 +19,24 @@ public class Cd implements Task {
         this.args = args;
     }
 
+    /**
+     * Change directory in the environment to:
+     * <p>
+     * * home directory if no arguments provided
+     * * to the directory specified by the relative path provided in the first argument
+     *
+     * @return empty string on success, string containing error description on failure
+     */
     @Override
     public String execute(Environment environment) throws Exception {
-        if (args.length > 1) {
+        if (args.length == 0) {
             Path homePath = Paths.get(System.getProperty("user.home")).toAbsolutePath();
             environment.setCurrentPath(
                     homePath
             );
             return "";
         } else {
-            Path newPath = Paths.get(args[0]).resolve(environment.getCurrentPath());
+            Path newPath = environment.getCurrentPath().resolve(args[0]);
             if (Files.exists(newPath)) {
                 environment.setCurrentPath(newPath);
                 return "";

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Cd.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Cd.java
@@ -1,0 +1,51 @@
+package ru.hse.homework.realisation.execution.tasks;
+
+import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Cd implements Task {
+    public static final String COMMAND = "cd";
+    private String[] args;
+
+    @Override
+    public void setArgs(String[] args) throws Exception {
+        if (args.length > 1) {
+            throw new CdException("Wrong number of args in cd");
+        }
+        this.args = args;
+    }
+
+    @Override
+    public String execute(Environment environment) throws Exception {
+        if (args.length > 1) {
+            Path homePath = Paths.get(System.getProperty("user.home")).toAbsolutePath();
+            environment.setCurrentPath(
+                    homePath
+            );
+            return "";
+        } else {
+            Path newPath = Paths.get(args[0]).resolve(environment.getCurrentPath());
+            if (Files.exists(newPath)) {
+                environment.setCurrentPath(newPath);
+                return "";
+            } else {
+                return String.format("%s: %s: No such file or directory", COMMAND, args[0]);
+            }
+        }
+    }
+
+    @Override
+    public String[] getArgs() {
+        return new String[0];
+    }
+
+    public static class CdException extends Exception {
+        CdException(String message) {
+            super(message);
+        }
+    }
+}

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Echo.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Echo.java
@@ -1,6 +1,7 @@
 package ru.hse.homework.realisation.execution.tasks;
 
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 
 import java.util.Arrays;
 
@@ -16,7 +17,7 @@ public class Echo implements Task {
     }
 
     @Override
-    public String execute() throws Exception {
+    public String execute(Environment environment) throws Exception {
         StringBuilder result = new StringBuilder();
         for (String arg: args) {
             result.append(arg);

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Exit.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Exit.java
@@ -1,6 +1,7 @@
 package ru.hse.homework.realisation.execution.tasks;
 
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 
 public class Exit implements Task {
     public static final String COMMAND = "exit";
@@ -12,7 +13,7 @@ public class Exit implements Task {
     }
 
     @Override
-    public String execute() throws Exception {
+    public String execute(Environment environment) throws Exception {
         System.exit(0);
         return null;
     }

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Grep.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Grep.java
@@ -1,6 +1,7 @@
 package ru.hse.homework.realisation.execution.tasks;
 
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 
 import java.util.Arrays;
 import java.util.regex.Matcher;
@@ -20,7 +21,7 @@ public class Grep implements Task {
     }
 
     @Override
-    public String execute() throws Exception {
+    public String execute(Environment environment) throws Exception {
         String pattern = args[args.length - 2];
         String text = args[args.length - 1];
         if (Arrays.asList(args).contains("i")) {

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Ls.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Ls.java
@@ -1,0 +1,62 @@
+package ru.hse.homework.realisation.execution.tasks;
+
+import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Ls implements Task {
+    public static final String COMMAND = "ls";
+    private String[] args;
+
+    @Override
+    public void setArgs(String[] args) throws Exception {
+        if (args.length > 1) {
+            throw new Ls.LsException("Wrong number of args in ls");
+        }
+        this.args = args;
+    }
+
+    private String lsFrom(Path path) throws IOException {
+        DirectoryStream<Path> paths = Files.newDirectoryStream(path);
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Path childPath : paths) {
+            stringBuilder.append(childPath.toString());
+            stringBuilder.append('\n');
+        }
+        return stringBuilder.toString();
+    }
+
+    @Override
+    public String execute(Environment environment) throws Exception {
+        Path path;
+
+        if (args.length == 0) {
+            path = environment.getCurrentPath();
+        } else {
+            Path newPath = Paths.get(args[0]).resolve(environment.getCurrentPath());
+            if (Files.exists(newPath)) {
+                path = newPath;
+            } else {
+                return String.format("%s: %s: No such file or directory", COMMAND, args[0]);
+            }
+        }
+
+        return lsFrom(path);
+    }
+
+    @Override
+    public String[] getArgs() {
+        return new String[0];
+    }
+
+    public static class LsException extends Exception {
+        LsException(String message) {
+            super(message);
+        }
+    }
+}

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Ls.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Ls.java
@@ -11,7 +11,7 @@ import java.nio.file.Paths;
 
 public class Ls implements Task {
     public static final String COMMAND = "ls";
-    private String[] args;
+    private String[] args = new String[0];
 
     @Override
     public void setArgs(String[] args) throws Exception {
@@ -25,7 +25,7 @@ public class Ls implements Task {
         DirectoryStream<Path> paths = Files.newDirectoryStream(path);
         StringBuilder stringBuilder = new StringBuilder();
         for (Path childPath : paths) {
-            stringBuilder.append(childPath.toString());
+            stringBuilder.append(childPath.getFileName().toString());
             stringBuilder.append('\n');
         }
         return stringBuilder.toString();
@@ -34,18 +34,18 @@ public class Ls implements Task {
     @Override
     public String execute(Environment environment) throws Exception {
         Path path;
-
         if (args.length == 0) {
             path = environment.getCurrentPath();
-        } else {
-            Path newPath = Paths.get(args[0]).resolve(environment.getCurrentPath());
+        } else if (args.length == 1) {
+            Path newPath = environment.getCurrentPath().resolve(args[0]);
             if (Files.exists(newPath)) {
                 path = newPath;
             } else {
                 return String.format("%s: %s: No such file or directory", COMMAND, args[0]);
             }
+        } else {
+            return "Internal error: unhandled number of arguments: " + args.length;
         }
-
         return lsFrom(path);
     }
 

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Pwd.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Pwd.java
@@ -1,6 +1,7 @@
 package ru.hse.homework.realisation.execution.tasks;
 
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 
 import java.io.File;
 
@@ -14,8 +15,8 @@ public class Pwd implements Task {
     }
 
     @Override
-    public String execute() throws Exception {
-        return new File("").getAbsoluteFile().getAbsolutePath();
+    public String execute(Environment environment) throws Exception {
+        return environment.getCurrentPath().toAbsolutePath().toString();
     }
 
     @Override

--- a/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Wc.java
+++ b/bash/src/main/java/ru/hse/homework/realisation/execution/tasks/Wc.java
@@ -1,6 +1,7 @@
 package ru.hse.homework.realisation.execution.tasks;
 
 import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
 
 import java.util.Arrays;
 
@@ -18,7 +19,7 @@ public class Wc implements Task {
     }
 
     @Override
-    public String execute() {
+    public String execute(Environment environment) {
         int linesNum = arg.split("[\n\r]").length;
         int wordsNum = arg.split(" ").length;
         int byteNum = arg.getBytes().length;

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CatTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CatTest.java
@@ -21,7 +21,7 @@ public class CatTest {
         writer.close();
         Task catTask = new Cat();
         catTask.setArgs(new String[]{createdFile.getAbsolutePath()});
-        String res = catTask.execute();
+        String res = catTask.execute(null);
         assertEquals("Hello world!", res);
     }
 }

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CdTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CdTest.java
@@ -1,0 +1,22 @@
+package ru.hse.homework.realisation.execution.tasks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ru.hse.homework.interfaces.execution.Task;
+import ru.hse.homework.realisation.Environment;
+
+import java.io.*;
+
+import static org.junit.Assert.*;
+
+public class CdTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        Environment environment = new Environment();
+        System.out.println(environment.getCurrentPath().normalize().toString());
+    }
+}

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CdTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CdTest.java
@@ -1,22 +1,23 @@
 package ru.hse.homework.realisation.execution.tasks;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import ru.hse.homework.interfaces.execution.Task;
 import ru.hse.homework.realisation.Environment;
 
-import java.io.*;
+import java.io.File;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class CdTest {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
-
     @Test
-    public void test() throws Exception {
+    public void cdSomewhere() throws Exception {
         Environment environment = new Environment();
-        System.out.println(environment.getCurrentPath().normalize().toString());
+        String before = environment.getCurrentPath().toString();
+
+        Ls lsTask = new Ls();
+        lsTask.setArgs(new String[]{"src"});
+        String result = lsTask.execute(environment);
+
+        assertEquals("", result);
+        assertEquals(before + File.separator + "src", environment.getCurrentPath().toString());
     }
 }

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CdTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/CdTest.java
@@ -1,6 +1,8 @@
 package ru.hse.homework.realisation.execution.tasks;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import ru.hse.homework.realisation.Environment;
 
 import java.io.File;
@@ -8,16 +10,22 @@ import java.io.File;
 import static org.junit.Assert.assertEquals;
 
 public class CdTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
     public void cdSomewhere() throws Exception {
         Environment environment = new Environment();
-        String before = environment.getCurrentPath().toString();
+        environment.setCurrentPath(folder.getRoot().toPath());
 
-        Ls lsTask = new Ls();
-        lsTask.setArgs(new String[]{"src"});
-        String result = lsTask.execute(environment);
+        File innerFolder = folder.newFolder("innerFolder");
+
+        Cd cdTask = new Cd();
+        cdTask.setArgs(new String[]{"innerFolder"});
+        String result = cdTask.execute(environment);
 
         assertEquals("", result);
-        assertEquals(before + File.separator + "src", environment.getCurrentPath().toString());
+        assertEquals(innerFolder.getAbsolutePath(),
+                environment.getCurrentPath().toAbsolutePath().toString());
     }
 }

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/EchoTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/EchoTest.java
@@ -9,7 +9,7 @@ public class EchoTest {
     public void simpleTest() throws Exception {
         Task echoTask = new Echo();
         echoTask.setArgs(new String[]{"hello ", "world", "!"});
-        String res = echoTask.execute();
+        String res = echoTask.execute(null);
         assertEquals("hello world!", res);
     }
 
@@ -17,6 +17,6 @@ public class EchoTest {
     public void wrongInputTest() throws Exception {
         Task echoTask = new Echo();
         echoTask.setArgs(new String[0]);
-        echoTask.execute();
+        echoTask.execute(null);
     }
 }

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/GrepTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/GrepTest.java
@@ -10,7 +10,7 @@ public class GrepTest {
     public void simpleTest() throws Exception {
         Task grep = new Grep();
         grep.setArgs(new String[]{"aaa", "aaa bbb"});
-        String res = grep.execute();
+        String res = grep.execute(null);
         assertEquals("aaa", res);
     }
 
@@ -18,7 +18,7 @@ public class GrepTest {
     public void manyMatchesTest() throws Exception {
         Task grep = new Grep();
         grep.setArgs(new String[]{"a+", "a aa aaa bbb aaaa"});
-        String res = grep.execute();
+        String res = grep.execute(null);
         assertEquals("a aa aaa aaaa", res);
     }
 
@@ -26,7 +26,7 @@ public class GrepTest {
     public void caseTest() throws Exception {
         Task grep = new Grep();
         grep.setArgs(new String[]{"i", "hey", "Hey HEY HeY"});
-        String res = grep.execute();
+        String res = grep.execute(null);
         assertEquals("Hey HEY HeY", res);
     }
 
@@ -34,7 +34,7 @@ public class GrepTest {
     public void wordsTest() throws Exception {
         Task grep = new Grep();
         grep.setArgs(new String[]{"w", "hey", "hey world! heyworld"});
-        String res = grep.execute();
+        String res = grep.execute(null);
         assertEquals("hey", res);
     }
 
@@ -42,7 +42,7 @@ public class GrepTest {
     public void linesTest() throws Exception {
         Task grep = new Grep();
         grep.setArgs(new String[]{"A", "2", "summer", "i wont summer\nmore\nmore\nand more"});
-        String res = grep.execute();
+        String res = grep.execute(null);
         assertEquals("summer\nmore\nmore\n", res);
     }
 }

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/LsTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/LsTest.java
@@ -6,21 +6,57 @@ import org.junit.rules.TemporaryFolder;
 import ru.hse.homework.realisation.Environment;
 
 import java.io.File;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
 public class LsTest {
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Test
-    public void test() throws Exception {
+    public void lsInCurrentDir() throws Exception {
         Environment environment = new Environment();
+        environment.setCurrentPath(folder.getRoot().toPath());
+        folder.newFile("foo.cpp");
+        folder.newFile(".file");
+        folder.newFolder("innerFolder");
+
+        String[] expected = {"foo.cpp", "innerFolder", ".file"};
 
         Ls lsTask = new Ls();
         String result = lsTask.execute(environment);
 
-        assertEquals("bash.iml\n" +
-                "target\n" +
-                "pom.xml\n" +
-                ".idea\n" +
-                "src\n", result);
+        String[] actual = result.split("\n");
+
+        Arrays.sort(expected);
+        Arrays.sort(actual);
+
+        assertArrayEquals(expected, actual);
+    }
+
+    @Test
+    public void lsSomeDir() throws Exception {
+        Environment environment = new Environment();
+        environment.setCurrentPath(folder.getRoot().toPath());
+        folder.newFile("foo.cpp");
+        folder.newFile(".file");
+
+        File innerFolder = folder.newFolder("innerFolder");
+        folder.newFile(innerFolder.getName() + File.separator + "file1");
+        folder.newFolder(innerFolder.getName(), "folder1");
+
+        String[] expected = {"file1", "folder1"};
+
+        Ls lsTask = new Ls();
+        lsTask.setArgs(new String[]{"innerFolder"});
+        String result = lsTask.execute(environment);
+
+        String[] actual = result.split("\n");
+
+        Arrays.sort(expected);
+        Arrays.sort(actual);
+
+        assertArrayEquals(expected, actual);
     }
 }

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/LsTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/LsTest.java
@@ -1,0 +1,26 @@
+package ru.hse.homework.realisation.execution.tasks;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import ru.hse.homework.realisation.Environment;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class LsTest {
+    @Test
+    public void test() throws Exception {
+        Environment environment = new Environment();
+
+        Ls lsTask = new Ls();
+        String result = lsTask.execute(environment);
+
+        assertEquals("bash.iml\n" +
+                "target\n" +
+                "pom.xml\n" +
+                ".idea\n" +
+                "src\n", result);
+    }
+}

--- a/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/WcTest.java
+++ b/bash/src/test/java/ru/hse/homework/realisation/execution/tasks/WcTest.java
@@ -10,7 +10,7 @@ public class WcTest {
     public void simpleTest() throws Exception {
         Task wcTask = new Wc();
         wcTask.setArgs(new java.lang.String[]{"test test test\n line line line"});
-        String res = wcTask.execute();
+        String res = wcTask.execute(null);
         assertEquals("2 6 30", res);
     }
 }


### PR DESCRIPTION
Добавлен класс `Environment`, на данный момент хранящий и позволяющий изменять только текущую директорию, однако он может быть расширен в будущем и инкапсулировать в себе и другие сущности.

Рефакторинг для добавления этого класса был довольно простым (это следствие хорошей декомпозиции на классы): нужно было изменить сигнатуру у `Task.execute`, передав туда `Environment`. Для старых команд достаточно передать `null`, т.к. они не используют `Environment`.

При добавлении команд обнаружилась отчасти сложность: код для работы с аргументами можно было бы вынести в абстрактный класс `Task`, добавив предикат правильного количества аргументов в конструктор. На данный момент во всех командах кроме `wc` этот код `setArgs` и `getArgs` дублируется.